### PR TITLE
Turn off node_compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ This will build your application and publish it. If this is your first time publ
 
 ### Cloudflare Secrets
 
-Cloudflare Workers offer a [secrets infrastructure](https://developers.cloudflare.com/workers/platform/environment-variables#adding-secrets-via-wrangler) for storing an encrypted secret. You can use this instead of relying on an environment variable.
+Cloudflare Workers offer a [secrets infrastructure](https://developers.cloudflare.com/workers/platform/environment-variables#add-secrets-to-your-project) for storing an encrypted secret. You can use this instead of relying on an environment variable.
 
 1. Publish your worker at least once using the above instructions to bootstrap the worker.
-2. Remove the `DefinePlugin` from [`webpack.config.js`](webpack.config.js).
-3. Run `wrangler secret put STRIPE_API_KEY`. This will prompt you to enter your secret (ie. your Stripe API key). 
+2. Run `wrangler secret put STRIPE_API_KEY`. This will prompt you to enter your secret (ie. your Stripe API key). 
 
 This only needs to be done the first time you are configuring up your new worker. It will persist across deployments. Once set up, you can publish using:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "{{ authors }}",
   "license": "MIT",
   "dependencies": {
-    "stripe": "^11.3.0"
+    "stripe": "^11.10.0"
   },
   "devDependencies": {}
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,4 +3,3 @@ main = "src/index.js"
 compatibility_flags = []
 compatibility_date = "2022-12-12"
 workers_dev = true
-node_compat = true


### PR DESCRIPTION
Removed `node_compat` from configuration, this is no longer needed with stripe-node v11.10.0. 

Verified that `wrangler publish` successfully publishes to a worker that redirects to a Stripe Checkout site as expected.