### PR TITLE
chore: set appInfo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,14 @@
 const Stripe = require("stripe");
 
 async function handleRequest(request, env) {
-  const stripe = Stripe(env.STRIPE_API_KEY);
+  const stripe = Stripe(env.STRIPE_API_KEYY, {
+    apiVersion: '2023-08-16',
+    appInfo: { // For sample support and debugging, not required for production:
+      name: 'stripe-samples/stripe-node-cloudflare-worker-template',
+      version: '0.0.1',
+      url: 'https://github.com/stripe-samples'
+    }
+  });
   /*
    * Sample checkout integration which redirects a customer to a checkout page
    * for the specified line items.

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 const Stripe = require("stripe");
 
 async function handleRequest(request, env) {
-  const stripe = Stripe(env.STRIPE_API_KEYY, {
-    apiVersion: '2023-08-16',
+  const stripe = Stripe(env.STRIPE_API_KEY, {
     appInfo: { // For sample support and debugging, not required for production:
       name: 'stripe-samples/stripe-node-cloudflare-worker-template',
       version: '0.0.1',


### PR DESCRIPTION
Hello! I want to add the example name to send a user-agent via the AppInfo field.
https://stripe.com/docs/building-plugins#identify-plugin
Could you merge this PR to set the app info data?

Thanks.