### PR TITLE
add the webhook example

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,2 @@
+STRIPE_API_KEY='sk_test_xxx'
+STRIPE_WEBHOOK_SECRET='whsec_xxx'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wasm-pack.log
 worker/
 node_modules/
 .cargo-ok
+.dev.vars

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Finally, you can run this example by the following command:
 npm run dev
 ```
 
+You will get the local application URL like the following:
+
+```bash
+[mf:inf] Ready on http://0.0.0.0:51219 
+[mf:inf] - http://127.0.0.1:51219
+[mf:inf] - http://192.168.86.21:51219
+[mf:inf] - http://172.18.96.89:51219
+```
+
 ### [Optional] Run a webhook locally
 
 You can use the Stripe CLI to easily spin up a local webhook.
@@ -44,7 +53,7 @@ You can use the Stripe CLI to easily spin up a local webhook.
 First install the CLI and link your Stripe account.
 
 ```
-stripe listen --forward-to http://127.0.0.1:8787/webhook
+stripe listen --forward-to http://{REPLACE_TO_YOUR_LOCAL_APPLICATION_URL}/webhook
 ```
 
 The CLI will print a webhook secret key to the console. Set STRIPE_WEBHOOK_SECRET to this value in your .env file.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,51 @@ To generate using [wrangler](https://github.com/cloudflare/wrangler2)
 
 ```
 wrangler generate projectname https://github.com/stripe-samples/stripe-node-cloudflare-worker-template
+cd projectname
+npm install
 ```
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
+
+## How to run locally
+
+To add your STRIPE_API_KEY as a plaintext environment variable via wrangler:
+
+Rename and move the `.dev.vars.example` file into a file named `.dev.vars`. For example:
+
+```toml
+cp .dev.vars.example .dev.vars
+```
+
+Example .env file:
+
+```
+STRIPE_API_KEY='sk_test_xxx'
+```
+
+You will need a Stripe account in order to run the demo. Once you set up your account, go to the Stripe [developer dashboard](https://stripe.com/docs/development#api-keys) to find your API keys.
+
+Finally, you can run this example by the following command:
+
+```
+npm run dev
+```
+
+### [Optional] Run a webhook locally
+
+You can use the Stripe CLI to easily spin up a local webhook.
+
+First install the CLI and link your Stripe account.
+
+```
+stripe listen --forward-to http://127.0.0.1:8787/webhook
+```
+
+The CLI will print a webhook secret key to the console. Set STRIPE_WEBHOOK_SECRET to this value in your .env file.
+
+You should see events logged in the console where the CLI is running.
+
+When you are ready to create a live webhook endpoint, follow our guide in the docs on [configuring a webhook endpoint in the dashboard](https://stripe.com/docs/webhooks/setup#configure-webhook-settings).
 
 ## Publishing
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,17 @@
   "version": "1.0.0",
   "description": "A template for using stripe-node in a Cloudflare Worker",
   "main": "dist/worker.js",
-  "scripts": {},
+  "scripts": {
+    "dev": "wrangler dev src/index.js",
+    "deploy": "wrangler deploy --minify src/index.js"
+  },
   "author": "{{ authors }}",
   "license": "MIT",
   "dependencies": {
-    "stripe": "^11.10.0"
+    "hono": "^3.7.0",
+    "stripe": "^13.6.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "wrangler": "^3.9.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,14 @@
 const Stripe = require("stripe");
 
 async function handleRequest(request, env) {
-  const stripe = Stripe(env.STRIPE_API_KEY);
+  const stripe = Stripe(env.STRIPE_API_KEYY, {
+    apiVersion: '2023-08-16',
+    appInfo: { // For sample support and debugging, not required for production:
+      name: 'stripe-samples/stripe-node-cloudflare-worker-template',
+      version: '0.0.1',
+      url: 'https://github.com/stripe-samples'
+    }
+  });
   /*
    * Sample checkout integration which redirects a customer to a checkout page
    * for the specified line items.

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,20 @@
+const { Hono } = require("hono");
 const Stripe = require("stripe");
+const app = new Hono();
 
-async function handleRequest(request, env) {
-  const stripe = Stripe(env.STRIPE_API_KEY, {
+function createStripeClient(apiKey) {
+  return new Stripe(apiKey, {
+    httpClient: Stripe.createFetchHttpClient(),
     appInfo: { // For sample support and debugging, not required for production:
-      name: 'stripe-samples/stripe-node-cloudflare-worker-template',
-      version: '0.0.1',
-      url: 'https://github.com/stripe-samples'
+      name: "stripe-samples/stripe-node-cloudflare-worker-template",
+      version: "0.0.1",
+      url: "https://github.com/stripe-samples"
     }
   });
+}
+
+app.get("/", async (context) => {
+  const stripe = createStripeClient(context.env.STRIPE_API_KEY);
   /*
    * Sample checkout integration which redirects a customer to a checkout page
    * for the specified line items.
@@ -15,28 +22,55 @@ async function handleRequest(request, env) {
    * See https://stripe.com/docs/payments/accept-a-payment?integration=checkout.
    */
   const session = await stripe.checkout.sessions.create({
-    payment_method_types: ['card'],
+    payment_method_types: ["card"],
     line_items: [
       {
         price_data: {
-          currency: 'usd',
+          currency: "usd",
           product_data: {
-            name: 'T-shirt',
+            name: "T-shirt",
           },
           unit_amount: 2000,
         },
         quantity: 1,
       },
     ],
-    mode: 'payment',
-    success_url: 'https://example.com/success',
-    cancel_url: 'https://example.com/cancel',
+    mode: "payment",
+    success_url: "https://example.com/success",
+    cancel_url: "https://example.com/cancel",
   });
+  return context.redirect(session.url, 303);
+});
 
-  return Response.redirect(session.url, 303);
-};
+app.post("/webhook", async (context) => {
+    const stripe = createStripeClient(context.env.STRIPE_API_KEY);
+    const signature = context.req.raw.headers.get("stripe-signature");
+    try {
+        if (!signature) {
+            return context.text("", 400);
+        }
+        const body = await context.req.text();
+        const event = await stripe.webhooks.constructEventAsync(
+            body,
+            signature,
+            context.env.STRIPE_WEBHOOK_SECRET,
+            undefined,
+            Stripe.createSubtleCryptoProvider()
+        );
+        switch(event.type) {
+            case "payment_intent.created": {
+                console.log(event.data.object)
+                break
+            }
+            default:
+                break
+        }
+        return context.text("", 200);
+      } catch (err) {
+        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}`
+        console.log(errorMessage);
+        return context.text(errorMessage, 400);
+      }
+})
 
-export default {
-  fetch: handleRequest
-}
-
+export default app;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 const Stripe = require("stripe");
 
 async function handleRequest(request, env) {
-  const stripe = Stripe(env.STRIPE_API_KEYY, {
-    apiVersion: '2023-08-16',
+  const stripe = Stripe(env.STRIPE_API_KEY, {
     appInfo: { // For sample support and debugging, not required for production:
       name: 'stripe-samples/stripe-node-cloudflare-worker-template',
       version: '0.0.1',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,2 @@
 name = "my-stripe-worker"
-main = "src/index.js"
-compatibility_flags = []
-compatibility_date = "2022-12-12"
-workers_dev = true
+compatibility_date = "2023-01-01"


### PR DESCRIPTION
We'd like to show the example of building a new Stripe Webhook API using Cloudflare Workers:
Ref: https://blog.cloudflare.com/announcing-stripe-support-in-workers/

I've added the Hono framework to the path-based routing feature and created a new API path, `POST /webhook.`
We can test the new example by the instructions on the `README.md` file and also try it by using my example repo:

```
npx wrangler generate projectname https://github.com/hideokamoto-stripe/stripe-node-cloudflare-worker-template
cd projectname
npm install
cp .dev.vars.example .dev.vars
```

Example .env file:

```
STRIPE_API_KEY='sk_test_xxx'
```

And using Wrangler CLI to run this app in the local machine:

```
npm run dev
```