### PR TITLE
docs: add Troubleshooting section on the README.md about the Miniflar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,21 @@ This only needs to be done the first time you are configuring up your new worker
 ```bash
 wrangler publish
 ```
+
+## Troubleshooting
+
+### **MiniflareCoreError [ERR_RUNTIME_FAILURE]: The Workers runtime failed to start. There is likely additional logging output above.**
+
+Depending on the settings of your local machine, there may be failures when attempting to start the service in a local environment using Wrangler. According to a [GitHub issue](https://github.com/cloudflare/workers-sdk/issues/4709#issuecomment-1988694586), it could be related to the certificate file or network settings.
+
+To avoid using an invalid certificate file, please try starting the application with the following command:
+
+```bash
+NODE_EXTRA_CA_CERTS="" npm run dev
+```
+
+If it still does not work, you may need to change the `/etc/hosts/` file and add the following settings:
+
+```
+127.0.0.1       localhost
+```


### PR DESCRIPTION

When starting the demo application, I encountered the following error.

```bash
$ npm run dev

> project-name@1.0.0 dev
> wrangler dev src/index.js

 ⛅️ wrangler 3.57.1
-------------------
Using vars defined in .dev.vars
Your worker has access to the following bindings:
- Vars:
  - STRIPE_API_KEY: "(hidden)"
  - WRANGLER_LOG: "(hidden)"
⎔ Starting local server...
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [b] open a browser, [d] open Devtools, [l] turn off local mode, [c] clear console, [x] to exit                                                                                                                                      │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
/Users/hideokamoto/stripe/sandbox/javascript/hono/stripe-node-cloudflare-worker-template/node_modules/wrangler/wrangler-dist/cli.js:29749
            throw a;
            ^

MiniflareCoreError [ERR_RUNTIME_FAILURE]: The Workers runtime failed to start. There is likely additional logging output above.
    at #assembleAndUpdateConfig (/Users/hideokamoto/stripe/sandbox/javascript/hono/stripe-node-cloudflare-worker-template/node_modules/wrangler/node_modules/miniflare/dist/src/index.js:9111:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async #setOptions (/Users/hideokamoto/stripe/sandbox/javascript/hono/stripe-node-cloudflare-worker-template/node_modules/wrangler/node_modules/miniflare/dist/src/index.js:9234:5)
    at async Mutex.runWith (/Users/hideokamoto/stripe/sandbox/javascript/hono/stripe-node-cloudflare-worker-template/node_modules/wrangler/node_modules/miniflare/dist/src/index.js:3504:16) {
  code: 'ERR_RUNTIME_FAILURE',
  cause: undefined
}

Node.js v21.5.0
```


It took me some time to resolve the issue, so I created a pull request to add the solution to the README.md to help other developers. Since it involved changing the `/etc/hosts` file, Stripe employees might be particularly prone to encountering this issue.