### PR TITLE
chore: use the Hono middleware to setup the Stripe SDK

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,8 @@ app.get("/", async (context) => {
 });
 
 app.post("/webhook", async (context) => {
+  // Load the Stripe API key from context.
+  const { STRIPE_WEBHOOK_SECRET } = env(context);
     /**
      * Load the Stripe client from the context
      */
@@ -75,9 +77,7 @@ app.post("/webhook", async (context) => {
         const event = await stripe.webhooks.constructEventAsync(
             body,
             signature,
-            context.env.STRIPE_WEBHOOK_SECRET,
-            undefined,
-            Stripe.createSubtleCryptoProvider()
+            STRIPE_WEBHOOK_SECRET
         );
         switch(event.type) {
             case "payment_intent.created": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,39 @@
 const { Hono } = require("hono");
+const { env } = require("hono/adapter");
 const Stripe = require("stripe");
 const app = new Hono();
 
-function createStripeClient(apiKey) {
-  return new Stripe(apiKey, {
-    appInfo: { // For sample support and debugging, not required for production:
+/**
+ * Setup Stripe SDK prior to handling a request
+ */
+app.use('*', async (context, next) => {
+  // Load the Stripe API key from context.
+  const { STRIPE_API_KEY: stripeKey } = env(context);
+
+  // Instantiate the Stripe client object 
+  const stripe = new Stripe(stripeKey, {
+    appInfo: {
+      // For sample support and debugging, not required for production:
       name: "stripe-samples/stripe-node-cloudflare-worker-template",
       version: "0.0.1",
       url: "https://github.com/stripe-samples"
-    }
+    },
+    maxNetworkRetries: 3,
+    timeout: 30 * 1000,
   });
-}
+
+  // Set the Stripe client to the Variable context object
+  context.set("stripe", stripe);
+
+  await next();
+});
+
 
 app.get("/", async (context) => {
-  const stripe = createStripeClient(context.env.STRIPE_API_KEY);
+  /**
+   * Load the Stripe client from the context
+   */
+  const stripe = context.get('stripe');
   /*
    * Sample checkout integration which redirects a customer to a checkout page
    * for the specified line items.
@@ -42,7 +62,10 @@ app.get("/", async (context) => {
 });
 
 app.post("/webhook", async (context) => {
-    const stripe = createStripeClient(context.env.STRIPE_API_KEY);
+    /**
+     * Load the Stripe client from the context
+     */
+    const stripe = context.get('stripe');
     const signature = context.req.raw.headers.get("stripe-signature");
     try {
         if (!signature) {


### PR DESCRIPTION
## tl;dr;
Update the example code to setup the Stripe SDK.
We can easy to use Stripe SDK through by the useful helper functions provided by Hono.

## Motivation

Update the example code to set up the Stripe SDK.
We can easily use the Stripe SDK through the useful helper functions provided by Hono.

## Motivation
According to my experience in contributing to Hono's OSS, I realized we can make our example more convenient.
- https://github.com/honojs/website/pull/347
- https://github.com/honojs/examples/pull/124

So I updated this example to follow the best practices of honojs.

## Testing

This update will not changr the user experience. So please run this pull request locally and visit the root page.
If you can see the Stripe Checkout form, it works well.


## References

https://github.com/honojs/examples/tree/main/env-vars
https://hono.dev/snippets/stripe-webhook